### PR TITLE
use offset-aware datetime

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import re
 from sys import stdin
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from github import Github
 from github.Issue import Issue
 from msc_chart_generator.msc_chart import MSCChart, ChartType
@@ -36,7 +36,7 @@ def main():
     msc_chart = MSCChart(pygithub=g)
     msc_url_regex = re.compile(r"MSC([\d]{3,4})", re.IGNORECASE)
 
-    one_week_ago = datetime.now() - timedelta(days=7)
+    one_week_ago = datetime.now(timezone.utc) - timedelta(days=7)
 
     # Get MSC Issues
     new_mscs = r.get_issues(


### PR DESCRIPTION
Running the script today, I got (Python 3.11.2)

```
Traceback (most recent call last):
  File "/home/hubert/Projects/matrix/twim-spec-entry-generator/main.py", line 206, in <module>
    main()
  File "/home/hubert/Projects/matrix/twim-spec-entry-generator/main.py", line 82, in main
    new_mscs = [msc for msc in new_mscs if msc.created_at > one_week_ago]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hubert/Projects/matrix/twim-spec-entry-generator/main.py", line 82, in <listcomp>
    new_mscs = [msc for msc in new_mscs if msc.created_at > one_week_ago]
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

This change seems to make it work